### PR TITLE
US27, US28

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,6 +1,8 @@
 class Admin::MerchantsController < ApplicationController
   def index
     @merchants = Merchant.all
+    @enabled_merchants = Merchant.enabled
+    @disabled_merchants = Merchant.disabled
   end
 
   def show
@@ -14,14 +16,19 @@ class Admin::MerchantsController < ApplicationController
   def update
     merchant = Merchant.find(params[:id])
 
-    if merchant.update!(merchant_params)
-      flash[:notice] = "#{merchant.name}'s info updated successfully!"
-      redirect_to admin_merchant_path(merchant)
+    if params[:name].present?
+      if merchant.update!(merchant_params)
+        flash[:notice] = "#{merchant.name}'s info updated successfully!"
+        redirect_to admin_merchant_path(merchant)
+      end
+    else
+      merchant.update!(status: merchant_params[:status])
+      redirect_to admin_merchants_path
     end
   end
 
   private
   def merchant_params
-    params.permit(:name)
+    params.permit(:name, :status)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -7,6 +7,8 @@ class Merchant < ApplicationRecord
 
   validates :name, presence: true
 
+  enum :status, [:disabled, :enabled], validate: true
+
   def top_five_customers
     customers
     .joins(:transactions)

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,7 +1,31 @@
-<div id="merchant_names">
-  <ul>
-    <% @merchants.each do |merchant| %>
-      <li><%= link_to merchant.name, admin_merchant_path(merchant.id) %></li>
-    <% end %>
-  </ul>
+<div id="merchants_list">
+  <div id="enabled_merchants">
+    <h2> Enabled Merchants </h2>
+    <ul>
+      <% @enabled_merchants.each do |merchant| %>
+        <div id="merchant_<%= merchant.id %>">
+          <li>
+          <%= link_to merchant.name, admin_merchant_path(merchant.id) %>
+          <%= button_to "Disable", admin_merchant_path(merchant.id), params: { status: "disabled" },
+              method: :patch, data: { turbo: false } %>
+          </li>
+        </div>
+      <% end %>
+    </ul>
+  </div>
+
+  <div id="disabled_merchants">
+    <h2> Disabled Merchants </h2>
+    <ul>
+      <% @disabled_merchants.each do |merchant| %>
+        <div id="merchant_<%= merchant.id %>">
+          <li>
+          <%= link_to merchant.name, admin_merchant_path(merchant.id) %>
+          <%= button_to "Enable", admin_merchant_path(merchant.id), params: { status: "enabled" },
+              method: :patch, data: { turbo: false } %>
+          </li>
+        </div>
+      <% end %>
+    </ul>
+  </div>
 </div>

--- a/db/migrate/20240601174410_add_status_to_merchants.rb
+++ b/db/migrate/20240601174410_add_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchants < ActiveRecord::Migration[7.1]
+  def change
+    add_column :merchants, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_28_221431) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_01_174410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_221431) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status"
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/factories/merchant.rb
+++ b/spec/factories/merchant.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :merchant do
     name { Faker::Company.name }
+    status { Faker::Number.within(range: 0..1) }
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Admin Merchants Index" do
   describe "As an admin, when I visit the admin merchants index" do
     describe "User Story 24" do
       it "shows the name of each merchant" do
-        within("div#merchant_names") do
+        within("div#merchants_list") do
           @merchants.each do |merchant|
             expect(page).to have_content(merchant.name)
           end
@@ -21,7 +21,7 @@ RSpec.describe "Admin Merchants Index" do
 
     describe "User Story 25" do
       it "shows each merchant's name as a link" do
-        within("div#merchant_names") do
+        within("div#merchants_list") do
           @merchants.each do |merchant|
             expect(page).to have_link(merchant.name)
           end
@@ -32,6 +32,42 @@ RSpec.describe "Admin Merchants Index" do
         click_link(@merchant_test.name)
 
         expect(current_path).to eq(admin_merchant_path(@merchant_test.id))
+      end
+    end
+  end
+
+  describe "User Story 27" do
+    it "has an enable or disable button next to each merchant and when one of the buttons
+    is clicked, it redirects back to the index page and the merchant's status has changed" do
+      enabled_merchant = create(:merchant, status: 1)
+      disabled_merchant = create(:merchant, status: 0)
+
+      within("div#merchants_list") do
+        Merchant.all.each do |merchant|
+          within("div#merchant_#{merchant.id}") do
+            if merchant.enabled?
+              expect(page).to have_button("Disable")
+              expect(page).to_not have_button("Enable")
+              
+              click_button("Disable")
+              
+              expect(current_path).to eq(admin_merchants_path)
+              
+              expect(page).to have_button("Enable")
+              expect(page).to_not have_button("Disable")
+            else
+              expect(page).to have_button("Enable")
+              expect(page).to_not have_button("Disable")
+
+              click_button("Enable")
+
+              expect(current_path).to eq(admin_merchants_path)
+
+              expect(page).to have_button("Disable")
+              expect(page).to_not have_button("Enable")
+            end
+          end 
+        end
       end
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -76,6 +76,10 @@ RSpec.describe Merchant, type: :model do
     it { should validate_presence_of(:name) }
   end
 
+  describe 'enums' do
+    it { should define_enum_for(:status).with_values({ disabled: 0, enabled: 1}) }
+  end
+
   describe 'instance methods' do
     describe '#top_five_customers' do
       it 'returns the top five customers who had most successful transcations for merchant' do


### PR DESCRIPTION
- Added buttons to enable or disabled merchant.
- Added enums for merchant status
- Buttons redirect back to the admin merchants index.
- Merchants are separated into "Enabled" and "Disabled" sections.
- Followed TDD